### PR TITLE
Soluzione per LA7 e tutti i canali RAI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,34 +1,40 @@
-![release](https://img.shields.io/github/v/release/Tundrak/IPTV-Italia) ![downloads](https://img.shields.io/github/downloads/Tundrak/IPTV-Italia/total) ![size](https://img.shields.io/github/repo-size/Tundrak/IPTV-Italia)
-# IPTV-Italia
-Questa repository contiene tutti i link ai principali canali TV e Radio nazionali italiani in tre file m3u da aprire con un qualsiasi programma che supporti file playlist. I link sono tutti estrapolati dagli stream ufficiali, e per questo dovrebbero essere visibili legalmente soltanto all'interno dell'Italia. Intendo aggiornare i link non funzionanti o aggiungere nuovi canali se vedo commenti che lo chiedono ed è nelle mie capacità farlo legalmente.
+# IPTV-Italia (Fork personale di [Tundrak/IPTV-Italia](https://github.com/Tundrak/IPTV-Italia))
+![release](https://img.shields.io/github/v/release/scode26/IPTV-Italia)
+![downloads](https://img.shields.io/github/downloads/scode26/IPTV-Italia/total) 
+![size](https://img.shields.io/github/repo-size/scode26/IPTV-Italia)
 
-This repository contains all the links to the main national Italian TV and Radio channels in two m3u files to be used with any program that supports opening playlist files. The links are all extrapolated from the official streams, so they should only be legally watchable within Italy. I intend to update broken links or add new channels if I see comments asking for it and it is within my capabilities to do so legally.
+Questa è una **fork personale** della repository originale [Tundrak/IPTV-Italia](https://github.com/Tundrak/IPTV-Italia).
+Si tratta di una repo di **manutenzione personale**, in cui provo a tenere aggiornati i link dei canali principali.
 
-# Come usarla
-Apri [**questo link**](https://github.com/Tundrak/IPTV-Italia/releases) e scarica la versione più recente delle playlist. Poi aprile con il tuo Media Player preferito (ad esempio PotPlayer o MyIPTV Player).  
-**Alternativo**: copia gli indirizzi nella tabella sotto e incollali nella finestra "Apri flusso di rete" o "Apri URL" del tuo player per avere sempre le playlist più aggiornate senza dover mai scaricare nuovi file.
-(**iptvitaplus** contiene tutti i canali in iptvita, e inoltre include loghi e gruppi per i lettori più avanzati)
+I meriti per il progetto originale vanno interamente a [Tundrak](https://github.com/Tundrak).
 
-|    **iptvita.m3u**  |   https://github.com/Tundrak/IPTV-Italia/raw/main/iptvita.m3u    |
-|--------------------:|:----------------------------------------------------------------:|
-| **iptvitaplus.m3u** | https://github.com/Tundrak/IPTV-Italia/raw/main/iptvitaplus.m3u  |
-| **ipradioita.m3u**  |  https://github.com/Tundrak/IPTV-Italia/raw/main/ipradioita.m3u  |
+Di seguito riporto il README della Repository originale.
 
-# Cosa contiene
-Al momento i due file contengono i seguenti canali TV e radio:
+---
 
-| Canali TV | Canali Radio |
-|:-:|:-:|
-| [1] Rai 1<br>[2] Rai 2<br>[3] Rai 3<br>[4] Rete 4<br>[5] Canale 5<br>[6] Italia 1<br>[7] LA7<br>[8] TV8<br>[9] NOVE<br>[20] 20<br>[21] Rai 4<br>[22] Iris<br>[23] Rai 5<br>[24] Rai Movie<br>[25] Rai Premium<br>[26] Cielo<br>[27] Twenty Seven<br>[28] TV2000<br>[29] LA7d<br>[30] La 5<br>[31] Real Time<br>[32] QVC<br>[33] Food Network<br>[34] Cine34<br>[35] Focus<br>[36] RTL 102.5<br>[37] Warner TV<br>[38] Giallo<br>[39] Top Crime<br>[40] Boing<br>[41] K2<br>[42] Rai Gulp<br>[43] Rai Yoyo<br>[44] Frisbee<br>[46] Cartoonito<br>[47] Super!<br>[48] Rai News 24<br>[49] Italia 2<br>[50] Sky TG24<br>[51] TGCOM 24<br>[52] DMAX<br>[54] Rai Storia<br>[55] Mediaset Extra<br>[56] HGTV - Home&Garden<br>[57] Rai Scuola<br>[58] Rai Sport + HD<br>[59] Motor Trend<br>[60] Sportitalia<br>[62] Donna TV<br>[64] Supertennis<br>[65] ALMA TV<br>[66] Radio 105 TV<br>[67] R101 TV<br>[68] BOM CHANNEL<br>[69] Deejay TV<br>[70] RadioItaliaTV<br>[145] Padre Pio TV<br>[158] RADIO KISS KISS TV<br>[202] Rai Radio 2 Visual<br>[233] RTL 102.5 News<br>[257] VIRGIN RADIO<br>[258] RADIOFRECCIA<br>[262] Byoblu<br>[265] RDS Social TV<br>[266] RADIO ZETA<br>[713] Radio Capital TV<br>[715] M2O TV<br>[772] Radio Montecarlo TV<br>[831] RTV San Marino<br>[899] Radio TV Serie A con RDS | Rai Radio 1<br>Rai Radio 2<br>Rai Radio 3<br>Rai Isoradio<br>[DAB] Rai Radio 1 Sport<br>[DAB] Rai Radio 3 Classica<br>[DAB] No Name Radio<br>[DAB] Rai Radio Kids<br>[DAB] Rai Radio Live Napoli<br>[DAB] Rai Radio Techetè<br>[DAB] Rai Radio Tutta Italiana<br>[DAB] Rai GRParlamento<br>Radio Sportiva<br>RTL 102.5<br>Radio Freccia<br>Radio Zeta<br>[DAB] RTL 102.5 Best<br>[DAB] RTL 102.5 Bro&Sis<br>[DAB] RTL 102.5 Romeo&Juliet<br>[DAB] RTL 102.5 Napulè<br>[DAB] RTL 102.5 Doc<br>[DAB] RTL 102.5 News<br>Virgin Radio<br>[Web] Virgin Radio Classic Rock<br>[Web] Virgin Radio Rock Hits<br>[Web] Virgin Radio Rock Ballads<br>[Web] Virgin Radio Rock '70<br>[Web] Virgin Radio Rock '80<br>[Web] Virgin Radio Rock '90<br>[Web] Virgin Radio Rock 2K<br>[Web] Virgin Radio Hard Rock<br>[Web] Virgin Radio Rock Party<br>[Web] Virgin Radio Alternative Rock<br>[Web] Rockstar: AC/DC<br>[Web] Rockstar: Guns N'Roses<br>[Web] Rockstar: Rolling Stones<br>[Web] Rockstar: Pink Floyd<br>[Web] Rockstar: Queen<br>[Web] Rockstar: Aerosmith<br>[Web] Rockstar: Bon Jovi<br>[Web] Rockstar: Oasis<br>Radio KissKiss<br>Radio Italia<br>[DAB] Radio Italia Trend<br>[Web] Radio Italia Sanremo<br>Radio Montecarlo<br>R101<br>Radio Capital<br>[Web] Radio Capital Music<br>[Web] Radio Capital Classic Rock<br>[DAB] Radio Capital Funky Town<br>[Web] Radio Capital W L'Italia<br>[Web] Radio Capital Soft<br>Radio Deejay<br>[DAB] Deejay 30 Songs<br>[Web] Deejay 80<br>[Web] Deejay Time<br>[Web] Deejay Tropical Pizza<br>[Web] Deejay One Two One Two<br>[Web] Radio Linetti<br>[Web] Deejay Suona Italia<br>[Web] Deejay Gasolina<br>[Web] Deejay On The Road<br>[Web] Deejay One Love<br>Radio 105<br>Radio Subasio<br>[Web] Radio Subasio +<br>[Web] Radio Suby<br>[Web] Radio Subasio Collection<br>[Web] Radio Subasio Per un'Ora d'Amore<br>Radio Radicale<br>RDS<br>Radio 24<br>[DAB] ACI Radio<br>[DAB] Canale Italia +<br>m2o<br>Radio inBlu2000<br>Radio Maria<br>[DAB] Radio Vaticana (Ita) |
-
-## Grandi assenti
-Se riuscirò a trovare link ufficiali funzionanti, li aggiungerò il prima possibile!
-- Incredibilmente, **nessuno** (credo)
-
-## Problemi noti
-- VLC e tutti i player basati su di esso (come Fermata Auto per Android) potrebbero avere problemi nel riprodurre i canali (si sconsiglia l'uso di VLC e surrogati in generale per la visione della lista)
-- I numeri LCN dei canali regionali non sono accurati, perchè i canali regionali cambiano numero spesso anche tra provincia e provincia
-
-# Segnala problemi e chiedi nuovi canali
-Se un qualsiasi link a un canale TV o radio non funzionasse, basta segnalarmelo aprendo un'Issue da [**questo**](https://github.com/Tundrak/IPTV-Italia/issues/new?labels=Problema&template=problema-canale.md&title=%5BProblema%5D) link (ricorda prima di controllare se qualcun altro ha già creato un'Issue con un problema simile o se il problema è già conosciuto guardando nella sezione "Problemi Noti" o nelle note delle release).  
-Inoltre, accetto richieste per nuovi canali TV o radio nazionali (soprattutto i "grandi assenti" di cui sopra), se li posso aggiungere da fonti ufficiali. Basta aprire un'Issue da [**questo**](https://github.com/Tundrak/IPTV-Italia/issues/new?labels=Richiesta+canale&template=richiesta-canale.md&title=%5BRichiesta+Canale%5D) link.
+> ### 📄 README.md (release v03-2024) - Repository originale
+> Tratto da [Tundrak/IPTV-Italia](https://github.com/Tundrak/IPTV-Italia)
+>
+> ![release](https://img.shields.io/github/v/release/Tundrak/IPTV-Italia) ![downloads](https://img.shields.io/github/downloads/Tundrak/IPTV-Italia/total) ![size](https://img.shields.io/github/repo-size/Tundrak/IPTV-Italia)
+> # IPTV-Italia
+> Questa repository contiene tutti i link ai principali canali TV e Radio nazionali italiani in tre file m3u da aprire con un qualsiasi programma che supporti file playlist. I link sono tutti estrapolati dagli stream ufficiali, e per questo dovrebbero essere visibili legalmente soltanto all'interno dell'Italia. Intendo aggiornare i link non funzionanti o aggiungere nuovi canali se vedo commenti che lo chiedono ed è nelle mie capacità farlo legalmente.
+>
+> This repository contains all the links to the main national Italian TV and Radio channels in two m3u files to be used with any program that supports opening playlist files. The links are all extrapolated from the official streams, so they should only be legally watchable within Italy. I intend to update broken links or add new channels if I see comments asking for it and it is within my capabilities to do so legally.
+>
+> # Come usarla
+> Apri [**questo link**](https://github.com/Tundrak/IPTV-Italia/releases) e scarica la versione più recente delle playlist. Poi aprile con il tuo Media Player preferito (ad esempio PotPlayer o MyIPTV Player).  
+> **Alternativo**: copia gli indirizzi nella tabella sotto e incollali nella finestra "Apri flusso di rete" o "Apri URL" del tuo player per avere sempre le playlist più aggiornate senza dover mai scaricare nuovi file.
+> (**iptvitaplus** contiene tutti i canali in iptvita, e inoltre include loghi e gruppi per i lettori più avanzati)
+>
+> | **iptvita.m3u** | https://github.com/Tundrak/IPTV-Italia/raw/main/iptvita.m3u |
+> |----------------:|:-------------------------------------------------------------:|
+> | **iptvitaplus.m3u** | https://github.com/Tundrak/IPTV-Italia/raw/main/iptvitaplus.m3u |
+> | **ipradioita.m3u** | https://github.com/Tundrak/IPTV-Italia/raw/main/ipradioita.m3u |
+>
+> # Cosa contiene
+> Al momento i due file contengono i seguenti canali TV e radio:
+>
+> | Canali TV | Canali Radio |
+> |:-:|:-:|
+> | [1] Rai 1<br>[2] Rai 2<br>[3] Rai 3<br>[4] Rete 4<br>[5] Canale 5<br>[6] Italia 1<br>[7] LA7<br>[8] TV8<br>[9] NOVE<br>[20] 20<br>[21] Rai 4<br>[22] Iris<br>[23] Rai 5<br>[24] Rai Movie<br>[25] Rai Premium<br>[26] Cielo<br>[27] Twenty Seven<br>[28] TV2000<br>[29] LA7d<br>[30] La 5<br>[31] Real Time<br>[32] QVC<br>[33] Food Network<br>[34] Cine34<br>[35] Focus<br>[36] RTL 102.5<br>[37] Warner TV<br>[38] Giallo<br>[39] Top Crime<br>[40] Boing<br>[41] K2<br>[42] Rai Gulp<br>[43] Rai Yoyo<br>[44] Frisbee<br>[46] Cartoonito<br>[47] Super!<br>[48] Rai News 24<br>[49] Italia 2<br>[50] Sky TG24<br>[51] TGCOM 24<br>[52] DMAX<br>[54] Rai Storia<br>[55] Mediaset Extra<br>[56] HGTV - Home&Garden<br>[57] Rai Scuola<br>[58] Rai Sport + HD<br>[59] Motor Trend<br>[60] Sportitalia<br>[62] Donna TV<br>[64] Supertennis<br>[65] ALMA TV<br>[66] Radio 105 TV<br>[67] R101 TV<br>[68] BOM CHANNEL<br>[69] Deejay TV<br>[70] RadioItaliaTV<br>[145] Padre Pio TV<br>[158] RADIO KISS KISS TV<br>[202] Rai Radio 2 Visual<br>[233] RTL 102.5 News<br>[257] VIRGIN RADIO<br>[258] RADIOFRECCIA<br>[262] Byoblu<br>[265] RDS Social TV<br>[266] RADIO ZETA<br>[713] Radio Capital TV<br>[715] M2O TV<br>[772] Radio Montecarlo TV<br>[831] RTV San Marino<br>[899] Radio TV Serie A con RDS | Rai Radio 1<br>Rai Radio 2<br>Rai Radio 3<br>Rai Isoradio<br>[DAB] Rai Radio 1 Sport<br>[DAB] Rai Radio 3 Classica<br>[DAB] No Name Radio<br>[DAB] Rai Radio Kids<br>[DAB] Rai Radio Live Napoli<br>[DAB] Rai Radio Techetè<br>[DAB] Rai Radio Tutta Italiana<br>[DAB] Rai GRParlamento<br>Radio Sportiva<br>RTL 102.5<br>Radio Freccia<br>Radio Zeta<br>[DAB] RTL 102.5 Best<br>[DAB] RTL 102.5 Bro&Sis<br>[DAB] RTL 102.5 Romeo&Juliet<br>[DAB] RTL 102.5 Napulè<br>[DAB] RTL 102.5 Doc<br>[DAB] RTL 102.5 News<br>Virgin Radio<br>[Web] Virgin Radio Classic Rock<br>[Web] Virgin Radio Rock Hits<br>[Web] Virgin Radio Rock Ballads<br>[Web] Virgin Radio Rock '70<br>[Web] Virgin Radio Rock '80<br>[Web] Virgin Radio Rock '90<br>[Web] Virgin Radio Rock 2K<br>[Web] Virgin Radio Hard Rock<br>[Web] Virgin Radio Rock Party<br>[Web] Virgin Radio Alternative Rock<br>[Web] Rockstar: AC/DC<br>[Web] Rockstar: Guns N'Roses<br>[Web] Rockstar: Rolling Stones<br>[Web] Rockstar: Pink Floyd<br>[Web] Rockstar: Queen<br>[Web] Rockstar: Aerosmith<br>[Web] Rockstar: Bon Jovi<br>[Web] Rockstar: Oasis<br>Radio KissKiss<br>Radio Italia<br>[DAB] Radio Italia Trend<br>[Web] Radio Italia Sanremo<br>Radio Montecarlo<br>R101<br>Radio Capital<br>[Web] Radio Capital Music<br>[Web] Radio Capital Classic Rock<br>[DAB] Radio Capital Funky Town<br>[Web] Radio Capital W L'Italia<br>[Web] Radio Capital Soft<br>Radio Deejay<br>[DAB] Deejay 30 Songs<br>[Web] Deejay 80<br>[Web] Deejay Time<br>[Web] Deejay Tropical Pizza<br>[Web] Deejay One Two One Two<br>[Web] Radio Linetti<br>[Web] Deejay Suona Italia<br>[Web] Deejay Gasolina<br>[Web] Deejay On The Road<br>[Web] Deejay One Love<br>Radio 105<br>Radio Subasio<br>[Web] Radio Subasio +<br>[Web] Radio Suby<br>[Web] Radio Subasio Collection<br>[Web] Radio Subasio Per un'Ora d'Amore<br>Radio Radicale<br>RDS<br>Radio 24<br>[DAB] ACI Radio<br>[DAB] Canale Italia +<br>m2o<br>Radio inBlu2000<br>Radio Maria<br>[DAB] Radio Vaticana (Ita)
+--- 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ Questa è una **fork personale** della repository originale [Tundrak/IPTV-Italia
 Si tratta di una repo di **manutenzione personale**, in cui provo a tenere aggiornati i link dei canali principali.
 
 # Come usarla
-Apri [**questo link**](https://github.com/scode26/IPTV-Italia/releases) e scarica la versione più recente delle playlist. Poi aprile con il tuo Media Player preferito (ad esempio PotPlayer o MyIPTV Player).  
+Apri [**questo link**](https://github.com/scode26/IPTV-Italia/releases) e scarica la versione più recente delle playlist. Poi aprile con il tuo Media Player preferito (ad esempio PotPlayer o MyIPTV Player).
+
 **Alternativo**: copia gli indirizzi nella tabella sotto e incollali nella finestra "Apri flusso di rete" o "Apri URL" del tuo player per avere sempre le playlist più aggiornate senza dover mai scaricare nuovi file.
 (**iptvitaplus** contiene tutti i canali in iptvita, e inoltre include loghi e gruppi per i lettori più avanzati)
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,17 @@
 Questa è una **fork personale** della repository originale [Tundrak/IPTV-Italia](https://github.com/Tundrak/IPTV-Italia).
 Si tratta di una repo di **manutenzione personale**, in cui provo a tenere aggiornati i link dei canali principali.
 
+# Come usarla
+Apri [**questo link**](https://github.com/scode26/IPTV-Italia/releases) e scarica la versione più recente delle playlist. Poi aprile con il tuo Media Player preferito (ad esempio PotPlayer o MyIPTV Player).  
+**Alternativo**: copia gli indirizzi nella tabella sotto e incollali nella finestra "Apri flusso di rete" o "Apri URL" del tuo player per avere sempre le playlist più aggiornate senza dover mai scaricare nuovi file.
+(**iptvitaplus** contiene tutti i canali in iptvita, e inoltre include loghi e gruppi per i lettori più avanzati)
+
+|    **FILE**         |   Link Download    |
+|--------------------:|:----------------------------------------------------------------:|
+| **iptvitaplus.m3u** | https://github.com/scode26/IPTV-Italia/raw/main/iptvitaplus.m3u  |
+|    **iptvita.m3u**  |   https://github.com/Tundrak/IPTV-Italia/raw/main/iptvita.m3u    |
+
+# CREDITI
 I meriti per il progetto originale vanno interamente a [Tundrak](https://github.com/Tundrak).
 
 Di seguito riporto il README della Repository originale.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Apri [**questo link**](https://github.com/scode26/IPTV-Italia/releases) e scaric
 |    **FILE**         |   Link Download    |
 |--------------------:|:----------------------------------------------------------------:|
 | **iptvitaplus.m3u** | https://github.com/scode26/IPTV-Italia/raw/main/iptvitaplus.m3u  |
-|    **iptvita.m3u**  |   https://github.com/Tundrak/IPTV-Italia/raw/main/iptvita.m3u    |
+|    **iptvita.m3u**  |   https://github.com/scode26/IPTV-Italia/raw/main/iptvita.m3u    |
 
 # CREDITI
 I meriti per il progetto originale vanno interamente a [Tundrak](https://github.com/Tundrak).

--- a/iptvita.m3u
+++ b/iptvita.m3u
@@ -18,7 +18,7 @@ https://live03-col.msf.cdn.mediaset.net/live/ch-c5/c5-clr.isml/manifest.mpd
 #EXTVLCOPT:http-user-agent=HbbTV/1.6.1
 https://live03-col.msf.cdn.mediaset.net/live/ch-i1/i1-clr.isml/manifest.mpd
 #EXTINF:-1,[7] LA7
-https://jmp2.uk/stvp-ITBD1500002NL
+https://d1chghleocc9sm.cloudfront.net/v1/master/3722c60a815c199d9c0ef36c5b73da68a62b09d1/cc-evfku205gqrtf/Live.m3u8
 #EXTINF:-1,[8] TV8
 https://hlslive-web-gcdn-skycdn-it.akamaized.net/TACT/11223/tv8web/master.m3u8?hdnea=st=1701861650~exp=1765449000~acl=/*~hmac=84c9f3f71e57b13c3a67afa8b29a8591ea9ed84bf786524399545d94be1ec04d
 #EXTINF:-1,[9] NOVE

--- a/iptvita.m3u
+++ b/iptvita.m3u
@@ -1,13 +1,13 @@
 #EXTM3U
 #EXTINF:-1,[1] Rai 1
 #EXTVLCOPT:http-user-agent=HbbTV/1.6.1
-http://mediapolis.rai.it/relinker/relinkerServlet.htm?cont=2606803&output=7&forceUserAgent=raiplayappletv
+https://mediapolis.rai.it/relinker/relinkerServlet.htm?cont=2606803&output=7&forceUserAgent=raiplayappletv
 #EXTINF:-1,[2] Rai 2
 #EXTVLCOPT:http-user-agent=HbbTV/1.6.1
-http://mediapolis.rai.it/relinker/relinkerServlet.htm?cont=308718&output=7&forceUserAgent=raiplayappletv
+https://mediapolis.rai.it/relinker/relinkerServlet.htm?cont=308718&output=7&forceUserAgent=raiplayappletv
 #EXTINF:-1,[3] Rai 3
 #EXTVLCOPT:http-user-agent=HbbTV/1.6.1
-http://mediapolis.rai.it/relinker/relinkerServlet.htm?cont=308709&output=7&forceUserAgent=raiplayappletv
+https://mediapolis.rai.it/relinker/relinkerServlet.htm?cont=308709&output=7&forceUserAgent=raiplayappletv
 #EXTINF:-1,[4] Rete 4
 #EXTVLCOPT:http-user-agent=HbbTV/1.6.1
 https://live03-col.msf.cdn.mediaset.net/live/ch-r4/r4-clr.isml/manifest.mpd
@@ -18,7 +18,7 @@ https://live03-col.msf.cdn.mediaset.net/live/ch-c5/c5-clr.isml/manifest.mpd
 #EXTVLCOPT:http-user-agent=HbbTV/1.6.1
 https://live03-col.msf.cdn.mediaset.net/live/ch-i1/i1-clr.isml/manifest.mpd
 #EXTINF:-1,[7] LA7
-https://d3749synfikwkv.cloudfront.net/v1/master/3722c60a815c199d9c0ef36c5b73da68a62b09d1/cc-74ylxpgd78bpb/Live.m3u8
+https://jmp2.uk/stvp-ITBD1500002NL
 #EXTINF:-1,[8] TV8
 https://hlslive-web-gcdn-skycdn-it.akamaized.net/TACT/11223/tv8web/master.m3u8?hdnea=st=1701861650~exp=1765449000~acl=/*~hmac=84c9f3f71e57b13c3a67afa8b29a8591ea9ed84bf786524399545d94be1ec04d
 #EXTINF:-1,[9] NOVE
@@ -28,19 +28,19 @@ https://amg16146-wbdi-amg16146c1-samsung-it-1831.playouts.now.amagi.tv/playlist/
 https://live03-col.msf.cdn.mediaset.net/live/ch-lb/lb-clr.isml/manifest.mpd
 #EXTINF:-1,[21] Rai 4
 #EXTVLCOPT:http-user-agent=HbbTV/1.6.1
-http://mediapolis.rai.it/relinker/relinkerServlet.htm?cont=746966&output=7&forceUserAgent=raiplayappletv
+https://mediapolis.rai.it/relinker/relinkerServlet.htm?cont=746966&output=7&forceUserAgent=raiplayappletv
 #EXTINF:-1,[22] Iris
 #EXTVLCOPT:http-user-agent=HbbTV/1.6.1
 https://live03-col.msf.cdn.mediaset.net/live/ch-ki/ki-clr.isml/manifest.mpd
 #EXTINF:-1,[23] Rai 5
 #EXTVLCOPT:http-user-agent=HbbTV/1.6.1
-http://mediapolis.rai.it/relinker/relinkerServlet.htm?cont=395276&output=7&forceUserAgent=raiplayappletv
+https://mediapolis.rai.it/relinker/relinkerServlet.htm?cont=395276&output=7&forceUserAgent=raiplayappletv
 #EXTINF:-1,[24] Rai Movie
 #EXTVLCOPT:http-user-agent=HbbTV/1.6.1
-http://mediapolis.rai.it/relinker/relinkerServlet.htm?cont=747002&output=7&forceUserAgent=raiplayappletv
+https://mediapolis.rai.it/relinker/relinkerServlet.htm?cont=747002&output=7&forceUserAgent=raiplayappletv
 #EXTINF:-1,[25] Rai Premium
 #EXTVLCOPT:http-user-agent=HbbTV/1.6.1
-http://mediapolis.rai.it/relinker/relinkerServlet.htm?cont=746992&output=7&forceUserAgent=raiplayappletv
+https://mediapolis.rai.it/relinker/relinkerServlet.htm?cont=746992&output=7&forceUserAgent=raiplayappletv
 #EXTINF:-1,[26] Cielo
 https://hlslive-web-gcdn-skycdn-it.akamaized.net/TACT/11219/cieloweb/master.m3u8?hdnea=st=1701861650~exp=1765449000~acl=/*~hmac=84c9f3f71e57b13c3a67afa8b29a8591ea9ed84bf786524399545d94be1ec04d
 #EXTINF:-1,[27] Twenty Seven
@@ -81,10 +81,10 @@ https://live03-col.msf.cdn.mediaset.net/live/ch-kb/kb-clr.isml/manifest.mpd
 https://amg16146-wbdi-amg16146c6-samsung-it-1839.playouts.now.amagi.tv/playlist/amg16146-warnerbrosdiscoveryitalia-k2-samsungit/playlist.m3u8
 #EXTINF:-1,[42] Rai Gulp
 #EXTVLCOPT:http-user-agent=HbbTV/1.6.1
-http://mediapolis.rai.it/relinker/relinkerServlet.htm?cont=746953&output=7&forceUserAgent=raiplayappletv
+https://mediapolis.rai.it/relinker/relinkerServlet.htm?cont=746953&output=7&forceUserAgent=raiplayappletv
 #EXTINF:-1,[43] Rai Yoyo
 #EXTVLCOPT:http-user-agent=HbbTV/1.6.1
-http://mediapolis.rai.it/relinker/relinkerServlet.htm?cont=746899&output=7&forceUserAgent=raiplayappletv
+https://mediapolis.rai.it/relinker/relinkerServlet.htm?cont=746899&output=7&forceUserAgent=raiplayappletv
 #EXTINF:-1,[44] Frisbee
 https://amg16146-wbdi-amg16146c7-samsung-it-1840.playouts.now.amagi.tv/playlist/amg16146-warnerbrosdiscoveryitalia-frisbee-samsungit/playlist.m3u8
 #EXTINF:-1,[46] Cartoonito
@@ -94,7 +94,7 @@ https://live03-col.msf.cdn.mediaset.net/live/ch-la/la-clr.isml/manifest.mpd
 https://vimnitaly.akamaized.net/hls/live/2094034/super/master.m3u8
 #EXTINF:-1,[48] Rai News 24
 #EXTVLCOPT:http-user-agent=HbbTV/1.6.1
-http://mediapolis.rai.it/relinker/relinkerServlet.htm?cont=1&output=7&forceUserAgent=raiplayappletv
+https://mediapolis.rai.it/relinker/relinkerServlet.htm?cont=1&output=7&forceUserAgent=raiplayappletv
 #EXTINF:-1,[49] Italia 2
 #EXTVLCOPT:http-user-agent=HbbTV/1.6.1
 https://live03-col.msf.cdn.mediaset.net/live/ch-i2/i2-clr.isml/manifest.mpd
@@ -107,7 +107,7 @@ https://live03-col.msf.cdn.mediaset.net/live/ch-kf/kf-clr.isml/manifest.mpd
 https://amg16146-wbdi-amg16146c8-samsung-it-1841.playouts.now.amagi.tv/playlist/amg16146-warnerbrosdiscoveryitalia-dmax-samsungit/playlist.m3u8
 #EXTINF:-1,[54] Rai Storia
 #EXTVLCOPT:http-user-agent=HbbTV/1.6.1
-http://mediapolis.rai.it/relinker/relinkerServlet.htm?cont=746990&output=7&forceUserAgent=raiplayappletv
+https://mediapolis.rai.it/relinker/relinkerServlet.htm?cont=746990&output=7&forceUserAgent=raiplayappletv
 #EXTINF:-1,[55] Mediaset Extra
 #EXTVLCOPT:http-user-agent=HbbTV/1.6.1
 https://live03-col.msf.cdn.mediaset.net/live/ch-kq/kq-clr.isml/manifest.mpd
@@ -115,10 +115,10 @@ https://live03-col.msf.cdn.mediaset.net/live/ch-kq/kq-clr.isml/manifest.mpd
 https://amg16146-wbdi-amg16146c9-samsung-it-1842.playouts.now.amagi.tv/playlist/amg16146-warnerbrosdiscoveryitalia-hgtv-samsungit/playlist.m3u8
 #EXTINF:-1,[57] Rai Scuola
 #EXTVLCOPT:http-user-agent=HbbTV/1.6.1
-http://mediapolis.rai.it/relinker/relinkerServlet.htm?cont=747011&output=7&forceUserAgent=raiplayappletv
+https://mediapolis.rai.it/relinker/relinkerServlet.htm?cont=747011&output=7&forceUserAgent=raiplayappletv
 #EXTINF:-1,[58] Rai Sport + HD
 #EXTVLCOPT:http-user-agent=HbbTV/1.6.1
-http://mediapolis.rai.it/relinker/relinkerServlet.htm?cont=358025&output=7&forceUserAgent=raiplayappletv
+https://mediapolis.rai.it/relinker/relinkerServlet.htm?cont=358025&output=7&forceUserAgent=raiplayappletv
 #EXTINF:-1,[59] Motor Trend
 https://amg16146-wbdi-amg16146c10-samsung-it-1843.playouts.now.amagi.tv/playlist/amg16146-warnerbrosdiscoveryitalia-motortrend-samsungit/playlist.m3u8
 #EXTINF:-1,[60] Sportitalia
@@ -150,7 +150,7 @@ https://600f07e114306.streamlock.net/PadrePioTV/livestream/playlist.m3u8
 https://kk.fluid.stream/KKMulti/smil:KissKissTV.smil/playlist.m3u8
 #EXTINF:-1,[202] Rai Radio 2 Visual
 #EXTVLCOPT:http-user-agent=HbbTV/1.6.1
-http://mediapolis.rai.it/relinker/relinkerServlet.htm?cont=5674080&output=7&forceUserAgent=raiplayappletv
+https://mediapolis.rai.it/relinker/relinkerServlet.htm?cont=5674080&output=7&forceUserAgent=raiplayappletv
 #EXTINF:-1,[233] RTL 102.5 News
 https://dd782ed59e2a4e86aabf6fc508674b59.msvdn.net/live/S38122967/2lyQRIAAGgRR/playlist_video.m3u8
 #EXTINF:-1,[257] VIRGIN RADIO

--- a/iptvitaplus.m3u
+++ b/iptvitaplus.m3u
@@ -18,7 +18,7 @@ https://live03-col.msf.cdn.mediaset.net/live/ch-c5/c5-clr.isml/manifest.mpd
 #EXTVLCOPT:http-user-agent=HbbTV/1.6.1
 https://live03-col.msf.cdn.mediaset.net/live/ch-i1/i1-clr.isml/manifest.mpd
 #EXTINF:-1 tvg-id="La7.it" tvg-chno="7" tvg-logo="https://cdn.jsdelivr.net/gh/Tundrak/IPTV-Italia/logos/la7.png" group-title="Altro",LA7
-https://jmp2.uk/stvp-ITBD1500002NL
+https://d1chghleocc9sm.cloudfront.net/v1/master/3722c60a815c199d9c0ef36c5b73da68a62b09d1/cc-evfku205gqrtf/Live.m3u8
 #EXTINF:-1 tvg-id="Tv8.it" tvg-chno="8" tvg-logo="https://cdn.jsdelivr.net/gh/Tundrak/IPTV-Italia/logos/tv8.png" group-title="Sky",TV8
 https://hlslive-web-gcdn-skycdn-it.akamaized.net/TACT/11223/tv8web/master.m3u8?hdnea=st=1701861650~exp=1765449000~acl=/*~hmac=84c9f3f71e57b13c3a67afa8b29a8591ea9ed84bf786524399545d94be1ec04d
 #EXTINF:-1 tvg-id="Nove.it" tvg-chno="9" tvg-logo="https://cdn.jsdelivr.net/gh/Tundrak/IPTV-Italia/logos/nove.png" group-title="Discovery",NOVE

--- a/iptvitaplus.m3u
+++ b/iptvitaplus.m3u
@@ -1,13 +1,13 @@
 #EXTM3U
 #EXTINF:-1 tvg-id="Rai1.it" tvg-chno="1" tvg-logo="https://cdn.jsdelivr.net/gh/Tundrak/IPTV-Italia/logos/rai1.png" group-title="Rai",Rai 1
 #EXTVLCOPT:http-user-agent=HbbTV/1.6.1
-http://mediapolis.rai.it/relinker/relinkerServlet.htm?cont=2606803&output=7&forceUserAgent=raiplayappletv
+https://mediapolis.rai.it/relinker/relinkerServlet.htm?cont=2606803&output=7&forceUserAgent=raiplayappletv
 #EXTINF:-1 tvg-id="Rai2.it" tvg-chno="2" tvg-logo="https://cdn.jsdelivr.net/gh/Tundrak/IPTV-Italia/logos/rai2.png" group-title="Rai",Rai 2
 #EXTVLCOPT:http-user-agent=HbbTV/1.6.1
-http://mediapolis.rai.it/relinker/relinkerServlet.htm?cont=308718&output=7&forceUserAgent=raiplayappletv
+https://mediapolis.rai.it/relinker/relinkerServlet.htm?cont=308718&output=7&forceUserAgent=raiplayappletv
 #EXTINF:-1 tvg-id="Rai3.it" tvg-chno="3" tvg-logo="https://cdn.jsdelivr.net/gh/Tundrak/IPTV-Italia/logos/rai3.png" group-title="Rai",Rai 3
 #EXTVLCOPT:http-user-agent=HbbTV/1.6.1
-http://mediapolis.rai.it/relinker/relinkerServlet.htm?cont=308709&output=7&forceUserAgent=raiplayappletv
+https://mediapolis.rai.it/relinker/relinkerServlet.htm?cont=308709&output=7&forceUserAgent=raiplayappletv
 #EXTINF:-1 tvg-id="Rete4.it" tvg-chno="4" tvg-logo="https://cdn.jsdelivr.net/gh/Tundrak/IPTV-Italia/logos/rete4.png" group-title="Mediaset",Rete 4
 #EXTVLCOPT:http-user-agent=HbbTV/1.6.1
 https://live03-col.msf.cdn.mediaset.net/live/ch-r4/r4-clr.isml/manifest.mpd
@@ -18,7 +18,7 @@ https://live03-col.msf.cdn.mediaset.net/live/ch-c5/c5-clr.isml/manifest.mpd
 #EXTVLCOPT:http-user-agent=HbbTV/1.6.1
 https://live03-col.msf.cdn.mediaset.net/live/ch-i1/i1-clr.isml/manifest.mpd
 #EXTINF:-1 tvg-id="La7.it" tvg-chno="7" tvg-logo="https://cdn.jsdelivr.net/gh/Tundrak/IPTV-Italia/logos/la7.png" group-title="Altro",LA7
-https://d3749synfikwkv.cloudfront.net/v1/master/3722c60a815c199d9c0ef36c5b73da68a62b09d1/cc-74ylxpgd78bpb/Live.m3u8
+https://jmp2.uk/stvp-ITBD1500002NL
 #EXTINF:-1 tvg-id="Tv8.it" tvg-chno="8" tvg-logo="https://cdn.jsdelivr.net/gh/Tundrak/IPTV-Italia/logos/tv8.png" group-title="Sky",TV8
 https://hlslive-web-gcdn-skycdn-it.akamaized.net/TACT/11223/tv8web/master.m3u8?hdnea=st=1701861650~exp=1765449000~acl=/*~hmac=84c9f3f71e57b13c3a67afa8b29a8591ea9ed84bf786524399545d94be1ec04d
 #EXTINF:-1 tvg-id="Nove.it" tvg-chno="9" tvg-logo="https://cdn.jsdelivr.net/gh/Tundrak/IPTV-Italia/logos/nove.png" group-title="Discovery",NOVE
@@ -28,19 +28,19 @@ https://amg16146-wbdi-amg16146c1-samsung-it-1831.playouts.now.amagi.tv/playlist/
 https://live03-col.msf.cdn.mediaset.net/live/ch-lb/lb-clr.isml/manifest.mpd
 #EXTINF:-1 tvg-id="Rai4.it" tvg-chno="21" tvg-logo="https://cdn.jsdelivr.net/gh/Tundrak/IPTV-Italia/logos/rai4.png" group-title="Rai",Rai 4
 #EXTVLCOPT:http-user-agent=HbbTV/1.6.1
-http://mediapolis.rai.it/relinker/relinkerServlet.htm?cont=746966&output=7&forceUserAgent=raiplayappletv
+https://mediapolis.rai.it/relinker/relinkerServlet.htm?cont=746966&output=7&forceUserAgent=raiplayappletv
 #EXTINF:-1 tvg-id="Iris.it" tvg-chno="22" tvg-logo="https://cdn.jsdelivr.net/gh/Tundrak/IPTV-Italia/logos/iris.png" group-title="Mediaset",Iris
 #EXTVLCOPT:http-user-agent=HbbTV/1.6.1
 https://live03-col.msf.cdn.mediaset.net/live/ch-ki/ki-clr.isml/manifest.mpd
 #EXTINF:-1 tvg-id="Rai5.it" tvg-chno="23" tvg-logo="https://cdn.jsdelivr.net/gh/Tundrak/IPTV-Italia/logos/rai5.png" group-title="Rai",Rai 5
 #EXTVLCOPT:http-user-agent=HbbTV/1.6.1
-http://mediapolis.rai.it/relinker/relinkerServlet.htm?cont=395276&output=7&forceUserAgent=raiplayappletv
+https://mediapolis.rai.it/relinker/relinkerServlet.htm?cont=395276&output=7&forceUserAgent=raiplayappletv
 #EXTINF:-1 tvg-id="RaiMovie.it" tvg-chno="24" tvg-logo="https://cdn.jsdelivr.net/gh/Tundrak/IPTV-Italia/logos/raimovie.png" group-title="Rai",Rai Movie
 #EXTVLCOPT:http-user-agent=HbbTV/1.6.1
-http://mediapolis.rai.it/relinker/relinkerServlet.htm?cont=747002&output=7&forceUserAgent=raiplayappletv
+https://mediapolis.rai.it/relinker/relinkerServlet.htm?cont=747002&output=7&forceUserAgent=raiplayappletv
 #EXTINF:-1 tvg-id="RaiPremium.it" tvg-chno="25" tvg-logo="https://cdn.jsdelivr.net/gh/Tundrak/IPTV-Italia/logos/raipremium.png" group-title="Rai",Rai Premium
 #EXTVLCOPT:http-user-agent=HbbTV/1.6.1
-http://mediapolis.rai.it/relinker/relinkerServlet.htm?cont=746992&output=7&forceUserAgent=raiplayappletv
+https://mediapolis.rai.it/relinker/relinkerServlet.htm?cont=746992&output=7&forceUserAgent=raiplayappletv
 #EXTINF:-1 tvg-id="CieloTv.it" tvg-chno="26" tvg-logo="https://cdn.jsdelivr.net/gh/Tundrak/IPTV-Italia/logos/cielo.png" group-title="Sky",Cielo
 https://hlslive-web-gcdn-skycdn-it.akamaized.net/TACT/11219/cieloweb/master.m3u8?hdnea=st=1701861650~exp=1765449000~acl=/*~hmac=84c9f3f71e57b13c3a67afa8b29a8591ea9ed84bf786524399545d94be1ec04d
 #EXTINF:-1 tvg-id="TwentySeven.it" tvg-chno="27" tvg-logo="https://cdn.jsdelivr.net/gh/Tundrak/IPTV-Italia/logos/twentyseven.png" group-title="Mediaset",Twenty Seven
@@ -81,10 +81,10 @@ https://live03-col.msf.cdn.mediaset.net/live/ch-kb/kb-clr.isml/manifest.mpd
 https://amg16146-wbdi-amg16146c6-samsung-it-1839.playouts.now.amagi.tv/playlist/amg16146-warnerbrosdiscoveryitalia-k2-samsungit/playlist.m3u8
 #EXTINF:-1 tvg-id="RaiGulp.it" tvg-chno="42" tvg-logo="https://cdn.jsdelivr.net/gh/Tundrak/IPTV-Italia/logos/raigulp.png" group-title="Rai",Rai Gulp
 #EXTVLCOPT:http-user-agent=HbbTV/1.6.1
-http://mediapolis.rai.it/relinker/relinkerServlet.htm?cont=746953&output=7&forceUserAgent=raiplayappletv
+https://mediapolis.rai.it/relinker/relinkerServlet.htm?cont=746953&output=7&forceUserAgent=raiplayappletv
 #EXTINF:-1 tvg-id="RaiYoyo.it" tvg-chno="43" tvg-logo="https://cdn.jsdelivr.net/gh/Tundrak/IPTV-Italia/logos/raiyoyo.png" group-title="Rai",Rai Yoyo
 #EXTVLCOPT:http-user-agent=HbbTV/1.6.1
-http://mediapolis.rai.it/relinker/relinkerServlet.htm?cont=746899&output=7&forceUserAgent=raiplayappletv
+https://mediapolis.rai.it/relinker/relinkerServlet.htm?cont=746899&output=7&forceUserAgent=raiplayappletv
 #EXTINF:-1 tvg-id="Frisbee.it" tvg-chno="44" tvg-logo="https://cdn.jsdelivr.net/gh/Tundrak/IPTV-Italia/logos/frisbee.png" group-title="Discovery",Frisbee
 https://amg16146-wbdi-amg16146c7-samsung-it-1840.playouts.now.amagi.tv/playlist/amg16146-warnerbrosdiscoveryitalia-frisbee-samsungit/playlist.m3u8
 #EXTINF:-1 tvg-id="Cartoonito.it" tvg-chno="46" tvg-logo="https://cdn.jsdelivr.net/gh/Tundrak/IPTV-Italia/logos/cartoonito.png" group-title="Mediaset",Cartoonito
@@ -94,7 +94,7 @@ https://live03-col.msf.cdn.mediaset.net/live/ch-la/la-clr.isml/manifest.mpd
 https://vimnitaly.akamaized.net/hls/live/2094034/super/master.m3u8
 #EXTINF:-1 tvg-id="RaiNews24.it" tvg-chno="48" tvg-logo="https://cdn.jsdelivr.net/gh/Tundrak/IPTV-Italia/logos/rainews24.png" group-title="Rai",Rai News 24
 #EXTVLCOPT:http-user-agent=HbbTV/1.6.1
-http://mediapolis.rai.it/relinker/relinkerServlet.htm?cont=1&output=7&forceUserAgent=raiplayappletv
+https://mediapolis.rai.it/relinker/relinkerServlet.htm?cont=1&output=7&forceUserAgent=raiplayappletv
 #EXTINF:-1 tvg-id="Italia2.it" tvg-chno="49" tvg-logo="https://cdn.jsdelivr.net/gh/Tundrak/IPTV-Italia/logos/italia2.png" group-title="Mediaset",Italia 2
 #EXTVLCOPT:http-user-agent=HbbTV/1.6.1
 https://live03-col.msf.cdn.mediaset.net/live/ch-i2/i2-clr.isml/manifest.mpd
@@ -107,7 +107,7 @@ https://live03-col.msf.cdn.mediaset.net/live/ch-kf/kf-clr.isml/manifest.mpd
 https://amg16146-wbdi-amg16146c8-samsung-it-1841.playouts.now.amagi.tv/playlist/amg16146-warnerbrosdiscoveryitalia-dmax-samsungit/playlist.m3u8
 #EXTINF:-1 tvg-id="RaiStoria.it" tvg-chno="54" tvg-logo="https://cdn.jsdelivr.net/gh/Tundrak/IPTV-Italia/logos/raistoria.png" group-title="Rai",Rai Storia
 #EXTVLCOPT:http-user-agent=HbbTV/1.6.1
-http://mediapolis.rai.it/relinker/relinkerServlet.htm?cont=746990&output=7&forceUserAgent=raiplayappletv
+https://mediapolis.rai.it/relinker/relinkerServlet.htm?cont=746990&output=7&forceUserAgent=raiplayappletv
 #EXTINF:-1 tvg-id="MediasetExtra.it" tvg-chno="55" tvg-logo="https://cdn.jsdelivr.net/gh/Tundrak/IPTV-Italia/logos/mediasetextra.png" group-title="Mediaset",Mediaset Extra
 #EXTVLCOPT:http-user-agent=HbbTV/1.6.1
 https://live03-col.msf.cdn.mediaset.net/live/ch-kq/kq-clr.isml/manifest.mpd
@@ -115,10 +115,10 @@ https://live03-col.msf.cdn.mediaset.net/live/ch-kq/kq-clr.isml/manifest.mpd
 https://amg16146-wbdi-amg16146c9-samsung-it-1842.playouts.now.amagi.tv/playlist/amg16146-warnerbrosdiscoveryitalia-hgtv-samsungit/playlist.m3u8
 #EXTINF:-1 tvg-id="RaiScuola.it" tvg-chno="57" tvg-logo="https://cdn.jsdelivr.net/gh/Tundrak/IPTV-Italia/logos/raiscuola.png" group-title="Rai",Rai Scuola
 #EXTVLCOPT:http-user-agent=HbbTV/1.6.1
-http://mediapolis.rai.it/relinker/relinkerServlet.htm?cont=747011&output=7&forceUserAgent=raiplayappletv
+https://mediapolis.rai.it/relinker/relinkerServlet.htm?cont=747011&output=7&forceUserAgent=raiplayappletv
 #EXTINF:-1 tvg-id="RaiSport+HD.it" tvg-chno="58" tvg-logo="https://cdn.jsdelivr.net/gh/Tundrak/IPTV-Italia/logos/raisport+hd.png" group-title="Rai",Rai Sport + HD
 #EXTVLCOPT:http-user-agent=HbbTV/1.6.1
-http://mediapolis.rai.it/relinker/relinkerServlet.htm?cont=358025&output=7&forceUserAgent=raiplayappletv
+https://mediapolis.rai.it/relinker/relinkerServlet.htm?cont=358025&output=7&forceUserAgent=raiplayappletv
 #EXTINF:-1 tvg-id="MotorTrendTV.it" tvg-chno="59" tvg-logo="https://cdn.jsdelivr.net/gh/Tundrak/IPTV-Italia/logos/motortrend.png" group-title="Discovery",Motor Trend
 https://amg16146-wbdi-amg16146c10-samsung-it-1843.playouts.now.amagi.tv/playlist/amg16146-warnerbrosdiscoveryitalia-motortrend-samsungit/playlist.m3u8
 #EXTINF:-1 tvg-id="Sportitalia.it" tvg-chno="60" tvg-logo="https://cdn.jsdelivr.net/gh/Tundrak/IPTV-Italia/logos/sportitalia.png" group-title="Altro",Sportitalia
@@ -150,7 +150,7 @@ https://600f07e114306.streamlock.net/PadrePioTV/livestream/playlist.m3u8
 https://kk.fluid.stream/KKMulti/smil:KissKissTV.smil/playlist.m3u8
 #EXTINF:-1 tvg-id="RaiRadio2.it" tvg-chno="202" tvg-logo="https://cdn.jsdelivr.net/gh/Tundrak/IPTV-Italia/logos/rairadio2visual.png" group-title="Radio",Rai Radio 2 Visual
 #EXTVLCOPT:http-user-agent=HbbTV/1.6.1
-http://mediapolis.rai.it/relinker/relinkerServlet.htm?cont=5674080&output=7&forceUserAgent=raiplayappletv
+https://mediapolis.rai.it/relinker/relinkerServlet.htm?cont=5674080&output=7&forceUserAgent=raiplayappletv
 #EXTINF:-1 tvg-id="RTL102.5News.it" tvg-chno="233" tvg-logo="https://cdn.jsdelivr.net/gh/Tundrak/IPTV-Italia/logos/rtl1025tv.png" group-title="Radio",RTL 102.5 News
 https://dd782ed59e2a4e86aabf6fc508674b59.msvdn.net/live/S38122967/2lyQRIAAGgRR/playlist_video.m3u8
 #EXTINF:-1 tvg-id="VirginRadio.it" tvg-chno="257" tvg-logo="https://cdn.jsdelivr.net/gh/Tundrak/IPTV-Italia/logos/virginradiotv.png" group-title="Radio",VIRGIN RADIO


### PR DESCRIPTION
Per i canali RAI basta sostituire in tutti i link `http://` con `https:// `
Esempio nuovi link **RAI 1,2,3**:
https://mediapolis.rai.it/relinker/relinkerServlet.htm?cont=2606803&output=7&forceUserAgent=raiplayappletv
https://mediapolis.rai.it/relinker/relinkerServlet.htm?cont=308718&output=7&forceUserAgent=raiplayappletv
https://mediapolis.rai.it/relinker/relinkerServlet.htm?cont=308709&output=7&forceUserAgent=raiplayappletv

Per **LA7** c'è un nuovo link: https://jmp2.uk/stvp-ITBD1500002NL